### PR TITLE
Fix a memory leak when loading a new image

### DIFF
--- a/trabalho1/src/imageprocessing.y
+++ b/trabalho1/src/imageprocessing.y
@@ -28,6 +28,7 @@ EXPRESSAO:
         imagem I = abrir_imagem($3);
         printf("Li imagem %d por %d\n", I.width, I.height);
         salvar_imagem($1, &I);
+        liberar_imagem(&I);
                           }
 
     ;

--- a/trabalho1/src/lib_imageprocessing.c
+++ b/trabalho1/src/lib_imageprocessing.c
@@ -51,6 +51,12 @@ imagem abrir_imagem(char *nome_do_arquivo) {
 
 }
 
+void liberar_imagem(imagem *I) {
+  free(I->r);
+  free(I->g);
+  free(I->b);
+}
+
 void salvar_imagem(char *nome_do_arquivo, imagem *I) {
   FIBITMAP *bitmapOut;
   RGBQUAD color;


### PR DESCRIPTION
The image bitmap buffer wasn't been freed after saving the image to a
file, so a memory leak would occur every time a new image was loaded.

This pull request solves the problem by implementing the liberar_imagem() function and calling it after saving the image.